### PR TITLE
Fix semtag to use main branch instead of master

### DIFF
--- a/tools/semtag
+++ b/tools/semtag
@@ -50,7 +50,7 @@ Commands:
   getcurrent Returns the current version, based on the latest one, if there are uncommited or
                unstaged changes, they will be reflected in the version, adding the number of
                pending commits, current branch and commit hash.
-  final      Tags the current build as a final version, this only can be done on the master branch.
+  final      Tags the current build as a final version, this only can be done on the main branch.
   candidate  Tags the current build as a release candidate, the tag will contain all
                the commits from the last final version.
   alpha      Tags the current build as an alpha version, the tag will contain all
@@ -531,7 +531,7 @@ function get_current {
   else
     local __buildinfo="$(git rev-parse --short HEAD)"
     local __currentbranch="$(git rev-parse --abbrev-ref HEAD)"
-    if [ "$__currentbranch" != "master" ]; then
+    if [ "$__currentbranch" != "main" ]; then
       __buildinfo="$__currentbranch.$__buildinfo"
     fi
 
@@ -580,10 +580,10 @@ case $ACTION in
     ;;
   final)
     init
-    diff=$(git diff master | cat)
+    diff=$(git diff main | cat)
     if [ "$forcetag" == "false" ]; then
       if [ -n "$diff" ]; then
-        echo "ERROR: Branch must be updated with master for final versions"
+        echo "ERROR: Branch must be updated with main for final versions"
         exit 1
       fi
     fi


### PR DESCRIPTION
`semtag` uses `master` branch name for final releases, changing it to use `main` branch.